### PR TITLE
Fix outdated link in package.xml pointing to PCL's bug-tracker.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,7 @@
   <license>BSD</license>
 
   <url type="website">http://www.pointclouds.org</url>
-  <url type="bugtracker">http://dev.pointclouds.org</url>
+  <url type="bugtracker">https://github.com/PointCloudLibrary/pcl/issues</url>
   <url type="repository">https://github.com/PointCloudLibrary/pcl</url>
 
   <buildtool_depend>cmake</buildtool_depend>


### PR DESCRIPTION
Old [link](http://dev.pointclouds.org) in manifest appears to be dead. Updates it with the [one](https://github.com/PointCloudLibrary/pcl/issues) mentioned in the official PCL's [web-page](http://pointclouds.org/).
